### PR TITLE
remove experimental feature

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,6 @@ terraform {
       version = "~> 2.15.0"
     }
   }
-  experiments = [module_variable_optional_attrs]
 }
 
 data "azurerm_client_config" "current" {}


### PR DESCRIPTION
# Description

Since terraform version 1.3.0 optional() can be used without experimental features

